### PR TITLE
 feat(save image): output the file paths in the node

### DIFF
--- a/src/nodes/save_image_s3.py
+++ b/src/nodes/save_image_s3.py
@@ -83,4 +83,4 @@ class SaveImageS3:
                 if temp_file_path and os.path.exists(temp_file_path):
                     os.remove(temp_file_path)
 
-        return { "ui": { "images": results},  "result": (s3_image_paths,) }
+        return { "ui": { "images": results },  "result": (s3_image_paths,) }


### PR DESCRIPTION
When We upload images to S3, all is good, but will be nice to have the path of where our images were saved.

With this, you can connect the `show text` node and easily check the path.

So later you can use that path to know how to fetch your images.

![image](https://github.com/TemryL/ComfyS3/assets/31712515/89942f4d-97e8-4b41-8327-5aeb9c166159)
