### PR TITLE
config: enforce .env loading and auto-prepend folders to S3 paths

### DIFF
--- a/src/client_s3.py
+++ b/src/client_s3.py
@@ -1,11 +1,13 @@
 import os
-import boto3
-from .logger import logger
-from botocore.exceptions import NoCredentialsError
-from botocore.config import Config
 
+import boto3
+from botocore.config import Config
+from botocore.exceptions import NoCredentialsError
 from dotenv import load_dotenv
-load_dotenv()
+
+from .logger import logger
+
+load_dotenv(override=True)
 
 
 class S3:
@@ -82,12 +84,14 @@ class S3:
             err = f"Failed to create folder in S3: {e}"
             logger.error(err)
     
-    def download_file(self, s3_path, local_path):
+    def download_file(self, s3_path:str, local_path:str):
         local_dir = os.path.dirname(local_path)
         if not os.path.exists(local_dir):
             os.makedirs(local_dir)
         try:
             bucket = self.s3_client.Bucket(self.bucket_name)
+            if self.input_dir and not s3_path.startswith(f"/{self.input_dir}"):
+                s3_path = f"/{self.input_dir}/{s3_path.lstrip('/')}"
             bucket.download_file(s3_path, local_path)
             return local_path
         except NoCredentialsError:
@@ -100,6 +104,8 @@ class S3:
     def upload_file(self, local_path, s3_path):
         try:
             bucket = self.s3_client.Bucket(self.bucket_name)
+            if self.output_dir and not s3_path.startswith(f"/{self.output_dir}"):
+                s3_path = f"/{self.output_dir}/{s3_path.lstrip('/')}"
             bucket.upload_file(local_path, s3_path)
             return s3_path
         except NoCredentialsError:


### PR DESCRIPTION
The `Minio` client was detected in use, and it was found that the custom prefix was not used when downloading from S3 storage.
These changes check for and force they prepend.

I also found that if you apply .env changes and work with Docker and ComfyUI, you need to reload the whole container, not just restart the manager. This forces everything to be loaded from the .env file.